### PR TITLE
Wait on client-acceptor thread to prevent race condition

### DIFF
--- a/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
@@ -114,6 +114,10 @@ final class DefaultEventBusServer extends DefaultEventBus implements EventBusSer
         } catch (IOException ignored) {
         }
         acceptor.interrupt();
+        try {
+            acceptor.join();
+        } catch (InterruptedException ignored) {
+        }
         acceptor = null;
         for (DefaultEventBusClient client : getClients()) {
           client.close();


### PR DESCRIPTION
When creating a new instance of `DefaultEventBusServer` right after another has been closed may lead to an exception: `Cannot bind on 0.0.0.0:24842 ... already in use`. This is because the `client-acceptor` thread might be still running even though the `DefaultEventBusServer` has been closed. Simply calling `interrupt` on the thread doesn't end the it immediately, so there is a chance it will continue running for a short while and block the socket.
This patch simply waits until the `client-acceptor` dies to prevent the described race condition.