### PR TITLE
Allow for registration of listener before any potential process spawn (and event generation)

### DIFF
--- a/src/main/java/org/terracotta/ipceventbus/event/BaseBuilder.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/BaseBuilder.java
@@ -24,6 +24,7 @@ public class BaseBuilder<T extends BaseBuilder<T>> {
 
   String busId;
   ErrorListener errorListener = new RethrowingErrorListener();
+  Listeners listeners = new Listeners();
 
   BaseBuilder() {
   }
@@ -40,6 +41,27 @@ public class BaseBuilder<T extends BaseBuilder<T>> {
   }
 
   /**
+   * Register a new listener for an event
+   *
+   * @param event    The event name
+   * @param listener The listener to register
+   */
+  public T on(String event, EventListener listener) {
+    listeners.on(event).add(listener);
+    return (T) this;
+  }
+
+  /**
+   * Register a new listener for all event
+   *
+   * @param listener The listener to register
+   */
+  public T on(EventListener listener) {
+    listeners.on("").add(listener);
+    return (T) this;
+  }
+
+  /**
    * Registers an {@link ErrorListener} to handle exceptions thrown by {@link EventListener}. By default, exceptions are rethrown.
    *
    * @param listener The listener to use. Some default implementations are provided.
@@ -51,7 +73,7 @@ public class BaseBuilder<T extends BaseBuilder<T>> {
   }
 
   public EventBus build() throws EventBusException {
-    return new DefaultEventBus(busId != null ? busId : UUID.randomUUID().toString(), errorListener);
+    return new DefaultEventBus(busId != null ? busId : UUID.randomUUID().toString(), errorListener, listeners);
   }
 
 }

--- a/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBus.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBus.java
@@ -23,11 +23,16 @@ class DefaultEventBus implements EventBus {
 
   private final String uuid;
   private final ErrorListener errorListener;
-  protected final Listeners listeners = new Listeners();
+  protected final Listeners listeners;
 
   DefaultEventBus(String uuid, ErrorListener errorListener) {
+    this(uuid, errorListener, new Listeners());
+  }
+
+  DefaultEventBus(String uuid, ErrorListener errorListener, Listeners initialListeners) {
     this.uuid = uuid;
     this.errorListener = errorListener;
+    this.listeners = new Listeners(initialListeners);
   }
 
   @Override

--- a/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusClient.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusClient.java
@@ -33,12 +33,16 @@ class DefaultEventBusClient extends DefaultEventBus implements EventBusClient {
   private ObjectInputStream inputStream;
   private Thread receiver;
 
-  DefaultEventBusClient(Socket socket, ErrorListener listener) {
-    this(socket.getLocalAddress().getHostName() + ":" + socket.getLocalPort(), socket, listener);
+  DefaultEventBusClient(Socket socket, ErrorListener listener, Listeners initialListeners) {
+    this(socket.getLocalAddress().getHostName() + ":" + socket.getLocalPort(), socket, listener, initialListeners);
   }
 
   DefaultEventBusClient(String uuid, Socket socket, ErrorListener listener) {
-    super(uuid, listener);
+    this(uuid, socket, listener, new Listeners());
+  }
+
+  DefaultEventBusClient(String uuid, Socket socket, ErrorListener listener, Listeners initialListeners) {
+    super(uuid, listener, initialListeners);
     this.socket.set(socket);
     try {
       this.outputStream = new ObjectOutputStream(socket.getOutputStream());

--- a/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
@@ -100,6 +100,11 @@ final class DefaultEventBusServer extends DefaultEventBus implements EventBusSer
   }
 
   @Override
+  public String getServerHost() {
+    return serverSocket.get().getInetAddress().getHostName();
+  }
+
+  @Override
   public boolean isClosed() {
     return serverSocket.get() == null || serverSocket.get().isClosed();
   }
@@ -152,4 +157,8 @@ final class DefaultEventBusServer extends DefaultEventBus implements EventBusSer
     }
   }
 
+  @Override
+  public int getClientCount() {
+    return getClients().size();
+  }
 }

--- a/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/DefaultEventBusServer.java
@@ -38,8 +38,8 @@ final class DefaultEventBusServer extends DefaultEventBus implements EventBusSer
   private final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
   private Thread acceptor;
 
-  DefaultEventBusServer(String uuid, ServerSocket serverSocket, final ErrorListener errorListener) {
-    super(uuid, errorListener);
+  DefaultEventBusServer(String uuid, ServerSocket serverSocket, final ErrorListener errorListener, final Listeners listeners) {
+    super(uuid, errorListener, listeners);
     this.serverSocket.set(serverSocket);
     final EventListener listener = new EventListener() {
       @Override

--- a/src/main/java/org/terracotta/ipceventbus/event/EventBusClient.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/EventBusClient.java
@@ -52,7 +52,7 @@ public interface EventBusClient extends RemoteEventBus {
       try {
         Socket socket = SocketFactory.getDefault().createSocket();
         socket.connect(endpoint);
-        return busId == null ? new DefaultEventBusClient(socket, errorListener) : new DefaultEventBusClient(busId, socket, errorListener);
+        return busId == null ? new DefaultEventBusClient(socket, errorListener, listeners) : new DefaultEventBusClient(busId, socket, errorListener, listeners);
       } catch (IOException e) {
         throw new EventBusIOException("Bad endpoint: " + endpoint.getHostName() + ":" + endpoint.getPort() + " : " + e.getMessage(), e);
       }

--- a/src/main/java/org/terracotta/ipceventbus/event/EventBusServer.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/EventBusServer.java
@@ -54,7 +54,7 @@ public interface EventBusServer extends RemoteEventBus {
       try {
         ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket();
         serverSocket.bind(new InetSocketAddress(address, port));
-        return new DefaultEventBusServer(busId != null ? busId : (serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort()), serverSocket, errorListener);
+        return new DefaultEventBusServer(busId != null ? busId : (serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort()), serverSocket, errorListener, listeners);
       } catch (IOException e) {
         throw new EventBusIOException("Cannot bind on " + address + ":" + port + " : " + e.getMessage(), e);
       }

--- a/src/main/java/org/terracotta/ipceventbus/event/EventBusServer.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/EventBusServer.java
@@ -25,6 +25,8 @@ import java.net.ServerSocket;
  */
 public interface EventBusServer extends RemoteEventBus {
 
+  int getClientCount();
+
   final class Builder extends BaseBuilder<Builder> {
 
     int port = Integer.parseInt(System.getProperty("ipc.bus.port", "56789"));

--- a/src/main/java/org/terracotta/ipceventbus/event/Listeners.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/Listeners.java
@@ -17,16 +17,28 @@
 package org.terracotta.ipceventbus.event;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * @author Mathieu Carbou
  */
 final class Listeners {
 
-  private final ConcurrentMap<String, Collection<EventListener>> index = new ConcurrentHashMap<String, Collection<EventListener>>();
+  private final ConcurrentMap<String, Collection<EventListener>> index;
+
+  Listeners(Listeners original) {
+    this.index = new ConcurrentHashMap<>(original.index.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            e -> new CopyOnWriteArrayList<>(e.getValue()))));
+  }
+
+  Listeners() {
+    this.index = new ConcurrentHashMap<>();
+  }
 
   public Collection<EventListener> on(String event) {
     this.index.putIfAbsent(event, new CopyOnWriteArrayList<EventListener>());

--- a/src/main/java/org/terracotta/ipceventbus/event/RemoteEventBus.java
+++ b/src/main/java/org/terracotta/ipceventbus/event/RemoteEventBus.java
@@ -27,6 +27,8 @@ public interface RemoteEventBus extends EventBus, Closeable {
    */
   int getServerPort();
 
+  String getServerHost();
+
   boolean isClosed();
 
 }

--- a/src/main/java/org/terracotta/ipceventbus/proc/AnyProcess.java
+++ b/src/main/java/org/terracotta/ipceventbus/proc/AnyProcess.java
@@ -323,7 +323,7 @@ public class AnyProcess extends Process {
     return new AnyProcessBuilder<>();
   }
 
-  private static long getPid(Process process) {
+  protected static long getPid(Process process) {
     if (isWindows()) {
       if (isJnaAvailable()) {
         return Jna.getWindowsPid(process);
@@ -355,7 +355,7 @@ public class AnyProcess extends Process {
     return System.getProperty("os.name", "unknown").toLowerCase().contains("windows");
   }
 
-  protected final String getCurrentPid() {
+  protected static final String getCurrentPid() {
     try {
       return ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
     } catch (Exception ignored) {

--- a/src/main/java/org/terracotta/ipceventbus/proc/Bus.java
+++ b/src/main/java/org/terracotta/ipceventbus/proc/Bus.java
@@ -16,7 +16,7 @@
 
 package org.terracotta.ipceventbus.proc;
 
-import org.terracotta.ipceventbus.event.EventBusServer;
+import org.terracotta.ipceventbus.event.EventBusClient;
 import org.terracotta.ipceventbus.event.EventListenerSniffer;
 
 import java.lang.management.ManagementFactory;
@@ -26,20 +26,19 @@ import java.lang.management.ManagementFactory;
  */
 public final class Bus {
 
-  private static final EventBusServer bus;
+  private static final EventBusClient bus;
 
   static {
-    int port = 0;
-    if (System.getProperty("ipc.bus.port") != null) {
-      port = Integer.parseInt(System.getProperty("ipc.bus.port"));
-    }
+    String host = System.getProperty("ipc.bus.host");
+    int port = Integer.parseInt(System.getProperty("ipc.bus.port"));
     String pid = getCurrentPid();
+
     if (isDebug()) {
       System.out.println("[" + Boot.class.getSimpleName() + "] Child PID: " + pid);
-      System.out.println("[" + Boot.class.getSimpleName() + "] Starting EventBus Server " + pid + " on 0.0.0.0:" + port + "...");
+      System.out.println("[" + Boot.class.getSimpleName() + "] Connecting EventBus Client " + pid + " to " + host + ":" + port + "...");
     }
-    bus = new EventBusServer.Builder()
-        .listen(port)
+    bus = new EventBusClient.Builder()
+        .connect(host, port)
         .id(pid)
         .build();
     if (isDebug()) {
@@ -47,7 +46,7 @@ public final class Bus {
     }
   }
 
-  public static EventBusServer get() {
+  public static EventBusClient get() {
     return bus;
   }
 

--- a/src/main/java/org/terracotta/ipceventbus/proc/JavaProcessBuilder.java
+++ b/src/main/java/org/terracotta/ipceventbus/proc/JavaProcessBuilder.java
@@ -117,7 +117,6 @@ public class JavaProcessBuilder<T extends JavaProcess> extends AnyProcessBuilder
     return this;
   }
 
-  @Override
   protected void buildCommand() {
     if (mainClass == null) {
       throw new IllegalArgumentException("Missing main class");
@@ -155,13 +154,13 @@ public class JavaProcessBuilder<T extends JavaProcess> extends AnyProcessBuilder
     command.addAll(arguments);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  protected T wrap(Process process, List<String> command) {
+  public T build() {
+    buildCommand();
     return (T) new JavaProcess(
-        process,
-        pipeStdout, pipeStderr, pipeStdin, recordStdout, recordStderr, command, workingDir,
-        javaHome, javaExecutable, jvmArgs, classpath, mainClass, arguments, jvmProps);
+            createProcess(),
+            pipeStdout, pipeStderr, pipeStdin, recordStdout, recordStderr, command, workingDir,
+            javaHome, javaExecutable, jvmArgs, classpath, mainClass, arguments, jvmProps);
   }
 
   private static File findJavaExecutable(File javaHome) {


### PR DESCRIPTION
Expose listener registration via the builders. This means we can register listeners before the event bus is exposed to anyone or anything that could feed an event that might be of interest to the listener.