### PR TITLE
Sonatype URL using HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ limitations under the License.
       <distributionManagement>
         <repository>
           <id>sonatype-nexus-staging</id>
-          <url>http://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
       </distributionManagement>
     </profile>


### PR DESCRIPTION
New Sable firewall won't let sonatype uploads through on port 80